### PR TITLE
Fix download buttons

### DIFF
--- a/src/components/DownloadButton.vue
+++ b/src/components/DownloadButton.vue
@@ -112,13 +112,13 @@ export default {
 		promptStable() {
 			const name = this.prettifyName;
 			console.log(name);
-			window.location.assign(this.data.downloadUrl);
+			window.location.assign(this.data.downloadUrl.browser_download_url);
 			// window.ga("send", "event", "Action", "Download", name);
 		},
 		promptPreview() {
 			const name = this.prettifyName;
 			console.log(`${name} Preview`);
-			window.location.assign(this.data.downloadUrl);
+			window.location.assign(this.data.downloadUrl.browser_download_url);
 			// window.ga("send", "event", "Action", "Download", `${name} Preview`);
 		},
 	},


### PR DESCRIPTION
fixes the download buttons for tachiyomi stable and preview, neko, j2k, sy stable and preview, and az stable. Az preview is broken and throws errors since its just a link to an apk so not sure how to move forward with that